### PR TITLE
Fix compilation with -Werror=format-security

### DIFF
--- a/src/basecontent.c
+++ b/src/basecontent.c
@@ -13,8 +13,6 @@
 
 //#include "strutils.h"
 
-char errmess[256];
-
 SEXP basecontent(SEXP x)
 {
   SEXP rv, rownames, colnames, dimnames, dim;
@@ -50,8 +48,7 @@ SEXP basecontent(SEXP x)
 	ig++;
 	break;
       default:
-	sprintf(errmess, "Unknown base %c in row %d, column %d.", seq[j], i+1, j+1);
-	error(errmess);
+	error("Unknown base %c in row %d, column %d.", seq[j], i+1, j+1);
       }
     }
     INTEGER(rv)[i    ] = ia; 


### PR DESCRIPTION
When compiling with the `-Werror=format-security` flag on, we get the following error:
```
basecontent.c: In function ‘basecontent’:
basecontent.c:54:15: error: format not a string literal and no format arguments [-Werror=format-security]
   54 |         error(errmess);
      |               ^~~~~~~
```
Turns out `error` actually wraps a vararg function much like `printf` (see https://lukasstadler.github.io/RAPI/html/_error_8h.html) so we can simplify by just calling it with formatters.

After this change, the package builds:
```
* installing to library ‘/root/tmp/libdir’
* installing *source* package ‘oligo’ ...
** using staged installation
** libs
using C compiler: ‘gcc (GCC) 11.4.1 20231218 (Red Hat 11.4.1-3)’
gcc -I"/root/r/dist/include" -DNDEBUG  -I'/root/tmp/libdir/preprocessCore/include' -I/usr/local/include '-D_FORTIFY_SOURCE=2'   -fPIC  -g -O2 -Wall -pedantic -Werror=format-security -fexceptions -fstack-protector-strong -fstack-clash-protection -Werror=implicit-function-declaration -Wstrict-prototypes   -c basecontent.c -o basecontent.o
gcc -shared -L/root/r/dist/lib -L/usr/local/lib -o oligo.so DABG.o ParserGzXYS.o ParserXYS.o baseProfile.o basecontent.o chipbackground.o mas5calls.o rma2.o rma_common.o trimmed.o -lz -lgfortran -lm -llapack -lblas -L/root/r/dist/lib -lR
installing to /root/tmp/libdir/00LOCK-oligo/00new/oligo/libs
** R
** inst
** byte-compile and prepare package for lazy loading
Note: in method for ‘pm<-’ with signature
‘object="TilingFeatureSet",subset="ANY",target="ANY",value="array"’:
expanding the signature to include omitted arguments in definition:
subset = "missing", target = "missing"
Note: in method for ‘mm<-’ with signature
‘object="TilingFeatureSet",subset="ANY",target="ANY",value="array"’:
expanding the signature to include omitted arguments in definition:
subset = "missing", target = "missing"
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (oligo)
```
This is important for CRAN checks as they check with  `-Werror=format-security` where as BioC does not.
Probably a good idea to make sure it builds everywhere and also save 256 characters for the happy path.
